### PR TITLE
Add option for making possible to switch off usage of GlobalPathFinder

### DIFF
--- a/lib/path-finder.coffee
+++ b/lib/path-finder.coffee
@@ -4,20 +4,22 @@ PathFinderUtilities = require "./path-finder-utilities"
 
 module.exports =
 class PathFinder
-  constructor: (@finder, @editor, opts = {}) ->
+  constructor: ->
     utilities = new PathFinderUtilities()
 
     @quickFinder = new QuickPathFinder(utilities)
-    @globalFinder = new GlobalPathFinder(utilities)
+
+    if atom.config.get 'ruby-test-switcher.useGlobalPathFinder'
+      @globalFinder = new GlobalPathFinder(utilities)
 
   findTestPath: (sourcePath) ->
     quickPath = @quickFinder.findTestPath(sourcePath)
     return quickPath if quickPath
 
-    @globalFinder.findTestPath(sourcePath)
+    @globalFinder.findTestPath(sourcePath) if @globalFinder
 
   findSourcePath: (testPath) ->
     quickPath = @quickFinder.findSourcePath(testPath)
     return quickPath if quickPath
 
-    @globalFinder.findSourcePath(testPath)
+    @globalFinder.findSourcePath(testPath) if @globalFinder

--- a/lib/ruby-test-switcher.coffee
+++ b/lib/ruby-test-switcher.coffee
@@ -4,6 +4,12 @@ PathFinder = require "./path-finder"
 _ = require "underscore"
 
 module.exports = RubyTestSwitcher =
+  config:
+    useGlobalPathFinder:
+      title: "Enable support for looking up source and test files in 'non-standard' locations"
+      type: 'boolean'
+      default: true
+
   subscriptions: null
 
   activate: (_state) ->

--- a/spec/path-finder-spec.coffee
+++ b/spec/path-finder-spec.coffee
@@ -5,12 +5,22 @@ describe "PathFinder", ->
   [finder] = []
 
   beforeEach ->
+    atom.config.set('ruby-test-switcher.useGlobalPathFinder', true)
     finder = new PathFinder
     @rootPath = path.join(__dirname, "fixtures")
     waitsForPromise ->
       atom.workspace.open(@rootPath)
 
   describe "::findTestPath", ->
+    describe "with disabled useGlobalPathFinder option", ->
+      beforeEach ->
+        atom.config.set('ruby-test-switcher.useGlobalPathFinder', false)
+        finder = new PathFinder
+
+      it "retunrs undefined if file is in non-standard dir", ->
+        sourcePath = path.join(@rootPath, "lib", "rom", "rom_fake.rb")
+        expect(finder.findTestPath(sourcePath)).toBeUndefined()
+
     describe "with a source code filepath without related test file", ->
       it "returns undefined", ->
         sourcePath = path.join(@rootPath, "lib", "without_tests.rb")


### PR DESCRIPTION
I'm working on the project which has a lot of specs in non-standart directories. So when I'm trying to switch to the spec or source file the editor freezes for a huge amount of time (about 30-40 seconds). This also happens when the source file does not have the corresponding spec file at all.  

A long time ago I had commented out the usages of `GlobalPathFinder` locally, but today the package was updated and all my changes were rewritten. I'm suggesting making the usage of `GlobalPathFinder` optional
